### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "tinyalloc"
+description := "Tiny replacement for malloc/free in unmanaged, linear memory situations, e.g. WebAssembly and embedded devices."
+gitrepo     := "https://github.com/thi-ng/tinyalloc.git"
+homepage    := "https://github.com/thi-ng/tinyalloc/"
+license     := "Apache-2.0"
+version     := 96450f3 sha256:dac10a3a017d420f51d9027bec0ce9b431e4b59533d3daed765c11abd08707e0 https://github.com/thi-ng/tinyalloc/archive/96450f3.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

